### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM devilldon/py3-alpine:stable
 
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
+
 WORKDIR /BOT
 
 RUN chmod -R 777 /BOT


### PR DESCRIPTION
For me deploying on heroku always lead to build fail due to cryptography not being built. Saw it was a problem due to one of its dependencies Rust so added the environment var. It's was also one of the suggested troubleshooting ways. Would have created a issue but didn't find it on your repo.